### PR TITLE
Show loading indicator for tts

### DIFF
--- a/include/TimesTables/quiz.hpp
+++ b/include/TimesTables/quiz.hpp
@@ -11,7 +11,8 @@ namespace TimesTables {
 class Quiz
 {
 public:
-    void reset(QList<int> timesTables, FactorRange factorRange);
+    void setup(const QList<int> timesTables, const FactorRange factorRange);
+    bool isAvailable();
     Question firstQuestion();
     bool nextQuestion(Question &question);
     bool answerIsCorrect(const int answer);

--- a/src/OttqApp/QuizView.qml
+++ b/src/OttqApp/QuizView.qml
@@ -154,8 +154,6 @@ FocusScope {
     }
 
     Connections {
-        id: connectionTtsReady
-
         // The quiz should get started after the tts becomes available the
         // first time. Otherwise enqueueing the first question, in case of an
         // initial error state, would not be possible.

--- a/src/OttqApp/QuizView.qml
+++ b/src/OttqApp/QuizView.qml
@@ -28,6 +28,10 @@ FocusScope {
                 progressBarTtsLoading {
                     visible: false
                 }
+
+                labelNumQuestionsRemaining {
+                    visible: false
+                }
             }
         },
         State {
@@ -44,6 +48,10 @@ FocusScope {
                 progressBarTtsLoading {
                     visible: true
                 }
+
+                labelNumQuestionsRemaining {
+                    visible: false
+                }
             }
         },
         State {
@@ -59,6 +67,10 @@ FocusScope {
                 progressBarTtsLoading {
                     visible: false
                 }
+
+                labelNumQuestionsRemaining {
+                    visible: true
+                }
             }
         },
         State {
@@ -73,6 +85,10 @@ FocusScope {
                 }
 
                 progressBarTtsLoading {
+                    visible: false
+                }
+
+                labelNumQuestionsRemaining {
                     visible: false
                 }
             }
@@ -112,6 +128,8 @@ FocusScope {
     // Times Tables:
 
     Label {
+        id: labelNumQuestionsRemaining
+
         anchors.right: parent.right
         anchors.rightMargin: 2
         anchors.top: parent.top

--- a/src/OttqApp/QuizView.qml
+++ b/src/OttqApp/QuizView.qml
@@ -15,6 +15,18 @@ FocusScope {
     QuizBackend {
         id: quizBackend
 
+        Component.onCompleted: {
+            isAvailable = quizBackend.setupQuiz(QuizConfiguration.timesTables, QuizConfiguration.minFactor, QuizConfiguration.maxFactor);
+            if (!isAvailable)
+                return;
+            if (tts.state == TextToSpeech.Error) {
+                progressBarTtsLoading.visible = true;
+                connectionTtsReady.enabled = true;
+            } else {
+                progressBarTtsLoading.visible = false;
+                quizBackend.startQuiz();
+            }
+        }
         onAvailabilityChanged: {
             if (isAvailable) {
                 answerInput.state = "available";
@@ -125,7 +137,7 @@ FocusScope {
 
         anchors.centerIn: parent
         indeterminate: true
-        visible: true
+        visible: false
         width: parent.width - 2 * 10
     }
 
@@ -162,11 +174,12 @@ FocusScope {
 
         function onStateChanged() {
             if (tts.state == TextToSpeech.Ready) {
-                quizBackend.startQuiz(QuizConfiguration.timesTables, QuizConfiguration.minFactor, QuizConfiguration.maxFactor);
-                target = null; // Call once.
+                quizBackend.startQuiz();
+                target = null; // Start quiz only once.
             }
         }
 
+        enabled: false
         target: tts
     }
 

--- a/src/OttqApp/QuizView.qml
+++ b/src/OttqApp/QuizView.qml
@@ -154,6 +154,8 @@ FocusScope {
     }
 
     Connections {
+        id: connectionTtsReady
+
         // The quiz should get started after the tts becomes available the
         // first time. Otherwise enqueueing the first question, in case of an
         // initial error state, would not be possible.

--- a/src/OttqApp/QuizView.qml
+++ b/src/OttqApp/QuizView.qml
@@ -120,6 +120,15 @@ FocusScope {
         }
     }
 
+    ProgressBar {
+        id: progressBarTtsLoading
+
+        anchors.centerIn: parent
+        indeterminate: true
+        visible: true
+        width: parent.width - 2 * 10
+    }
+
     Label {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 2
@@ -165,6 +174,17 @@ FocusScope {
         function onAboutToSynthesize() {
             tts.setUp();
             target = null; // Will be called only once.
+        }
+
+        target: tts
+    }
+
+    Connections {
+        function onStateChanged() {
+            if (tts.state == TextToSpeech.Speaking) {
+                progressBarTtsLoading.visible = false;
+                target = null; // Call once.
+            }
         }
 
         target: tts

--- a/src/OttqApp/i18n/qml_de.ts
+++ b/src/OttqApp/i18n/qml_de.ts
@@ -73,6 +73,11 @@
         <source>Completed</source>
         <translation>Beendet</translation>
     </message>
+    <message>
+        <location filename="../QuizView.qml" line="44"/>
+        <source>Text-to-Speech Loading</source>
+        <translation>Text-to-Speech lädt</translation>
+    </message>
 </context>
 <context>
     <name>SettingsView</name>

--- a/src/OttqApp/quiz_backend.cpp
+++ b/src/OttqApp/quiz_backend.cpp
@@ -56,7 +56,7 @@ bool QuizBackend::setupQuiz(const QList<int> tables, const int minFactor,
     translator_.translate(questionBase_);
 
     bool ok = quiz_.isAvailable();
-    setAvailability(ok);
+    isAvailable_ = ok; // initialize backend with quiz model availability
     return ok;
 }
 

--- a/src/OttqApp/quiz_backend.cpp
+++ b/src/OttqApp/quiz_backend.cpp
@@ -7,7 +7,7 @@
 #include <QtLogging>
 
 QuizBackend::QuizBackend(QObject *parent)
-    : QObject(parent), isAvailable_(false), questionBase_("%1 times %2")
+    : QObject(parent), isAvailable_(true), questionBase_("%1 times %2")
 {
 }
 
@@ -54,10 +54,7 @@ bool QuizBackend::setupQuiz(const QList<int> tables, const int minFactor,
 {
     quiz_.setup(tables, TimesTables::FactorRange(minFactor, maxFactor));
     translator_.translate(questionBase_);
-
-    bool ok = quiz_.isAvailable();
-    isAvailable_ = ok; // initialize backend with quiz model availability
-    return ok;
+    return quiz_.isAvailable() && translator_.isAvailable();
 }
 
 void QuizBackend::startQuiz()

--- a/src/OttqApp/quiz_backend.cpp
+++ b/src/OttqApp/quiz_backend.cpp
@@ -25,7 +25,7 @@ double QuizBackend::voiceRate()
 
 bool QuizBackend::isAvailable()
 {
-    return isAvailable_ && translator_.isAvailable();
+    return isAvailable_ && translator_.isAvailable() && quiz_.isAvailable();
 }
 
 int QuizBackend::numQuestionsRemaining()
@@ -49,15 +49,21 @@ void QuizBackend::setAvailability(const bool &isAvailable)
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-void QuizBackend::startQuiz(const QList<int> tables, const int minFactor,
+bool QuizBackend::setupQuiz(const QList<int> tables, const int minFactor,
                             const int maxFactor)
 {
-    quiz_.reset(tables, TimesTables::FactorRange(minFactor, maxFactor));
+    quiz_.setup(tables, TimesTables::FactorRange(minFactor, maxFactor));
     translator_.translate(questionBase_);
 
+    bool ok = quiz_.isAvailable();
+    setAvailability(ok);
+    return ok;
+}
+
+void QuizBackend::startQuiz()
+{
     try {
         TimesTables::Question q = quiz_.firstQuestion();
-        setAvailability(true);
         emit questionChanged(questionBase_.arg(q.factor).arg(q.number));
         emit numQuestionsRemainingChanged();
     } catch (std::out_of_range &e) {

--- a/src/OttqApp/quiz_backend.hpp
+++ b/src/OttqApp/quiz_backend.hpp
@@ -34,8 +34,9 @@ public:
 
     void setAvailability(const bool &isAvailable);
 
-    Q_INVOKABLE void startQuiz(const QList<int> tables, const int minFactor,
+    Q_INVOKABLE bool setupQuiz(const QList<int> tables, const int minFactor,
                                const int maxFactor);
+    Q_INVOKABLE void startQuiz();
     Q_INVOKABLE void check(const QString input);
 
 signals:

--- a/src/TimesTables/quiz.cpp
+++ b/src/TimesTables/quiz.cpp
@@ -2,10 +2,16 @@
 #include <ranges>
 #include <random>
 
-void TimesTables::Quiz::reset(QList<int> timesTables, FactorRange factorRange)
+void TimesTables::Quiz::setup(const QList<int> timesTables,
+                              const FactorRange factorRange)
 {
     questions_.clear();
     generateQuestions(timesTables, factorRange);
+}
+
+bool TimesTables::Quiz::isAvailable()
+{
+    return !questions_.empty();
 }
 
 void TimesTables::Quiz::generateQuestions(const QList<int> tables,


### PR DESCRIPTION
In the quiz view on Android, setting up the tts and synthesizing the first time takes 10 seconds upwards. This PR contains a loading indicator (maybe simply a progress bar?) to show.

In case the available/unavailable logic in the backend clashes with the state for the progress bar, I'd try to find a better state logic in this PR too.

- [x] show progress indicator
- [x] check state switch for backend and progress bar
    - [x] move quiz setup from tts state 'ready' to component creation, so the tts
states can be ignored if there are no questions

