### PR TITLE
Avoid loading tts on every quiz start

### DIFF
--- a/src/OttqApp/CMakeLists.txt
+++ b/src/OttqApp/CMakeLists.txt
@@ -30,6 +30,7 @@ qt_add_qml_module(OTTQ
         settings_backend.cpp
         quiz_configuration.hpp
         quiz_configuration.cpp
+        language_name.hpp
 )
 
 qt_add_translations(OTTQ

--- a/src/OttqApp/SettingsView.qml
+++ b/src/OttqApp/SettingsView.qml
@@ -31,10 +31,8 @@ Item {
                 maximumLineCount: 2
                 opacity: switchTtsLocale.checked ? 1 : 0.5
                 text: {
-                    var l = Qt.locale(settingsBackend.autoLocaleName);
-                    var language = l.nativeLanguageName;
-                    var territory = l.nativeTerritoryName;
-                    return "%1\n(%2)".arg(language).arg(territory);
+                    var l = settingsBackend.autoLanguage;
+                    return "%1\n(%2)".arg(l.language).arg(l.territory);
                 }
                 width: sRoot.parentWidth - switchTtsLocale.width - 3 * 10
                 wrapMode: Text.WordWrap

--- a/src/OttqApp/language_name.hpp
+++ b/src/OttqApp/language_name.hpp
@@ -1,0 +1,32 @@
+#ifndef LANGUAGE_NAME_HPP
+#define LANGUAGE_NAME_HPP
+
+#include <QObject>
+#include <qqml.h>
+#include <QString>
+#include <QLocale>
+
+struct LanguageName
+{
+    Q_GADGET
+    Q_PROPERTY(QString language READ language CONSTANT FINAL)
+    Q_PROPERTY(QString territory READ territory CONSTANT FINAL)
+    QML_ANONYMOUS
+
+public:
+    LanguageName() : language_(""), territory_("") { }
+    LanguageName(const QLocale locale)
+        : language_(locale.nativeLanguageName()),
+          territory_(locale.nativeTerritoryName())
+    {
+    }
+
+    QString language() { return language_; }
+    QString territory() { return territory_; }
+
+private:
+    QString language_;
+    QString territory_;
+};
+
+#endif // LANGUAGE_NAME_HPP

--- a/src/OttqApp/quiz_backend.hpp
+++ b/src/OttqApp/quiz_backend.hpp
@@ -11,17 +11,22 @@
 class QuizBackend : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QString localeName READ localeName NOTIFY localeNameChanged)
-    Q_PROPERTY(double voiceRate READ voiceRate NOTIFY voiceRateChanged)
-    Q_PROPERTY(QString question READ question NOTIFY questionChanged)
+    Q_PROPERTY(double voiceRate READ voiceRate NOTIFY voiceRateChanged FINAL)
+    Q_PROPERTY(QString question READ question NOTIFY questionChanged FINAL)
     // clang-format off
+    Q_PROPERTY(QString localeName
+               READ localeName
+               NOTIFY localeNameChanged
+               FINAL)
     Q_PROPERTY(bool isAvailable
                READ isAvailable
                WRITE setAvailability
-               NOTIFY availabilityChanged)
+               NOTIFY availabilityChanged
+               FINAL)
     Q_PROPERTY(int numQuestionsRemaining
                READ numQuestionsRemaining
-               NOTIFY numQuestionsRemainingChanged)
+               NOTIFY numQuestionsRemainingChanged
+               FINAL)
     // clang-format on
     QML_ELEMENT
 

--- a/src/OttqApp/quiz_configuration.hpp
+++ b/src/OttqApp/quiz_configuration.hpp
@@ -10,19 +10,23 @@ class QuizConfiguration : public QObject
     Q_OBJECT
     // clang-format off
     Q_PROPERTY(QString timesTablesStr
-        READ timesTablesStr
-        NOTIFY timesTablesStrChanged)
+               READ timesTablesStr
+               NOTIFY timesTablesStrChanged
+               FINAL)
     Q_PROPERTY(QList<int> timesTables
-        READ timesTables
-        NOTIFY timesTablesChanged)
+               READ timesTables
+               NOTIFY timesTablesChanged
+               FINAL)
     Q_PROPERTY(int minFactor
-        READ minFactor
-        WRITE setMinFactor
-        NOTIFY minFactorChanged)
+               READ minFactor
+               WRITE setMinFactor
+               NOTIFY minFactorChanged
+               FINAL)
     Q_PROPERTY(int maxFactor
-        READ maxFactor
-        WRITE setMaxFactor
-        NOTIFY maxFactorChanged)
+               READ maxFactor
+               WRITE setMaxFactor
+               NOTIFY maxFactorChanged
+               FINAL)
     // clang-format on
     QML_SINGLETON
     QML_ELEMENT

--- a/src/OttqApp/settings_backend.cpp
+++ b/src/OttqApp/settings_backend.cpp
@@ -1,7 +1,7 @@
 #include "settings_backend.hpp"
 #include "auto_locale.hpp"
 
-SettingsBackend::SettingsBackend(QObject *parent) : QObject{ parent } { }
+SettingsBackend::SettingsBackend(QObject *parent) : QObject(parent) { }
 
 QStringList SettingsBackend::languages()
 {
@@ -18,9 +18,10 @@ bool SettingsBackend::useAutoTtsLanguage()
     return languageSettings_.isInAutoMode();
 }
 
-QString SettingsBackend::autoLocaleName()
+auto SettingsBackend::autoLanguage() -> LanguageName
 {
-    return Tts::autoLocale().name();
+    LanguageName l(Tts::autoLocale());
+    return l;
 }
 
 double SettingsBackend::voiceRate()

--- a/src/OttqApp/settings_backend.hpp
+++ b/src/OttqApp/settings_backend.hpp
@@ -11,22 +11,29 @@ class SettingsBackend : public QObject
 {
     Q_OBJECT
     // clang-format off
-    Q_PROPERTY(QStringList languages READ languages NOTIFY languagesChanged)
+    Q_PROPERTY(QStringList languages
+               READ languages
+               NOTIFY languagesChanged
+               FINAL)
     Q_PROPERTY(int languageIndex
                READ languageIndex
                WRITE setLanguageIndex
-               NOTIFY languageIndexChanged)
+               NOTIFY languageIndexChanged
+               FINAL)
     Q_PROPERTY(bool useAutoTtsLanguage
                READ useAutoTtsLanguage
                WRITE setUseAutoTtsLanguage
-               NOTIFY useAutoTtsLanguageChanged)
+               NOTIFY useAutoTtsLanguageChanged
+               FINAL)
     Q_PROPERTY(QString autoLocaleName
                READ autoLocaleName
-               NOTIFY autoLocaleNameChanged)
+               NOTIFY autoLocaleNameChanged
+               FINAL)
     Q_PROPERTY(double voiceRate
                READ voiceRate
                WRITE setVoiceRate
-               NOTIFY voiceRateChanged)
+               NOTIFY voiceRateChanged
+               FINAL)
     // clang-format on
     QML_ELEMENT
 

--- a/src/OttqApp/settings_backend.hpp
+++ b/src/OttqApp/settings_backend.hpp
@@ -3,6 +3,7 @@
 
 #include "tts_language_settings.hpp"
 #include "tts_rate_settings.hpp"
+#include "language_name.hpp"
 #include <QObject>
 #include <qqml.h>
 #include <QStringList>
@@ -25,9 +26,9 @@ class SettingsBackend : public QObject
                WRITE setUseAutoTtsLanguage
                NOTIFY useAutoTtsLanguageChanged
                FINAL)
-    Q_PROPERTY(QString autoLocaleName
-               READ autoLocaleName
-               NOTIFY autoLocaleNameChanged
+    Q_PROPERTY(LanguageName autoLanguage
+               READ autoLanguage
+               NOTIFY autoLanguageChanged
                FINAL)
     Q_PROPERTY(double voiceRate
                READ voiceRate
@@ -43,7 +44,7 @@ public:
     QStringList languages();
     int languageIndex();
     bool useAutoTtsLanguage();
-    QString autoLocaleName();
+    LanguageName autoLanguage();
     double voiceRate();
 
     void setLanguageIndex(const int index);
@@ -54,7 +55,7 @@ signals:
     void languagesChanged();
     void languageIndexChanged();
     void useAutoTtsLanguageChanged();
-    void autoLocaleNameChanged();
+    void autoLanguageChanged();
     void voiceRateChanged();
 
 private:


### PR DESCRIPTION
In this PR the tts object is moved so the instance can be kept while the app is open (and if the locale was not changed).
Currently, a new tts instance is created every time the quiz view is entered, which can be seen by tts loading every time. This is not the expected behavior when starting multiple quizzes without leaving the app (or changing the locale).

Current considerations are:
- A state machine might help decoupling
- Consider moving tts to the backend. While it is an auditory interface to the user, it's not visual and there is a C++ class.
    It could help decoupling further, and give more options as to where to put the tts object.
- It would be nice to not use a Singleton
- If tts is initialized on app start, it might slow down app start (as currently seen when navigating to the quiz view)
- If the instance is not created on quiz start anymore, the tts instance needs to be updated with any change in the locale (system or settings)